### PR TITLE
Change `role_name` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ module "ecr" {
 
 ## Outputs
 
-| Name                | Description                                                                              |
+| Name                | Description                                                                             |
 |:-------------------:|:---------------------------------------------------------------------------------------:|
-| `registry_id`       | ID of the created AWS Container Registry                                                    |
-| `registry_url`      | URL to the created AWS Container Registry                                                   |
-| `role_name`         | (Optional) The name of the newly created IAM role that has access to the registry                                    |
+| `registry_id`       | ID of the created AWS Container Registry                                                |
+| `registry_url`      | URL to the created AWS Container Registry                                               |
+| `role_name`         | (Optional) The name of the newly created IAM role that has access to the registry       |
 
 
 ## License

--- a/output.tf
+++ b/output.tf
@@ -11,5 +11,5 @@ output "repository_name" {
 }
 
 output "role_name" {
-  value = "${aws_iam_role.default.name}"
+  value = "${join("", aws_iam_role.default.*.name)}"
 }


### PR DESCRIPTION
## what
* Change `role_name` output to use splat syntax

## why
* To prevent this warning
```
Warning: output "role_name": must use splat syntax to access aws_iam_role.default attribute "name", 
because it has "count" set; 
use aws_iam_role.default.*.name to obtain a list of the attributes across all instances
```
