### PR TITLE
Added lifecycle policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "ecr" {
 | `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
 | `name`                       | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
 | `roles`                      | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
+| `max_image_count`            | `7`            | How many Docker Image versions AWS ECR will store | Yes |
 
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -146,6 +146,7 @@ resource "aws_iam_instance_profile" "default" {
 
 resource "aws_ecr_lifecycle_policy" "default" {
   repository = "${aws_ecr_repository.default.name}"
+
   policy = <<EOF
 {
   "rules": [{

--- a/main.tf
+++ b/main.tf
@@ -151,11 +151,11 @@ resource "aws_ecr_lifecycle_policy" "default" {
 {
   "rules": [{
     "rulePriority": 1,
-    "description": "Rotate images when reach ${var.max_image_number} images stored",
+    "description": "Rotate images when reach ${var.max_image_count} images stored",
     "selection": {
       "tagStatus": "untagged",
       "countType": "imageCountMoreThan",
-      "countNumber": ${var.max_image_number}
+      "countNumber": ${var.max_image_count}
     },
     "action": {
       "type": "expire"

--- a/main.tf
+++ b/main.tf
@@ -150,11 +150,11 @@ resource "aws_ecr_lifecycle_policy" "default" {
 {
   "rules": [{
     "rulePriority": 1,
-    "description": "Rotate images when reach ${var.rotate_number} images stored",
+    "description": "Rotate images when reach ${var.max_image_number} images stored",
     "selection": {
       "tagStatus": "untagged",
       "countType": "imageCountMoreThan",
-      "countNumber": ${var.rotate_number}
+      "countNumber": ${var.max_image_number}
     },
     "action": {
       "type": "expire"

--- a/main.tf
+++ b/main.tf
@@ -143,3 +143,23 @@ resource "aws_iam_instance_profile" "default" {
   name  = "${module.label.id}"
   role  = "${aws_iam_role.default.name}"
 }
+
+resource "aws_ecr_lifecycle_policy" "default" {
+  repository = "${aws_ecr_repository.default.name}"
+  policy = <<EOF
+{
+  "rules": [{
+    "rulePriority": 1,
+    "description": "Rotate images when reach ${var.rotate_number} images stored",
+    "selection": {
+      "tagStatus": "untagged",
+      "countType": "imageCountMoreThan",
+      "countNumber": ${var.rotate_number}
+    },
+    "action": {
+      "type": "expire"
+    }
+  }]
+}
+EOF
+}

--- a/main.tf
+++ b/main.tf
@@ -146,14 +146,14 @@ resource "aws_iam_instance_profile" "default" {
 
 resource "aws_ecr_lifecycle_policy" "default" {
   repository = "${aws_ecr_repository.default.name}"
-
   policy = <<EOF
 {
   "rules": [{
     "rulePriority": 1,
     "description": "Rotate images when reach ${var.max_image_count} images stored",
     "selection": {
-      "tagStatus": "untagged",
+      "tagStatus": "tagged",
+      "tagPrefixList": ["${var.stage}"],
       "countType": "imageCountMoreThan",
       "countNumber": ${var.max_image_count}
     },

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "tags" {
 }
 
 variable "max_image_number" {
-  type    = "string"
+  type        = "string"
   description = "How many Docker Image versions AWS ECR will store"
-  default = "7"
+  default     = "7"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "tags" {
   default = {}
 }
 
-variable "rotate_number" {
+variable "max_image_number" {
   type    = "string"
   description = "How many Docker Image versions AWS ECR will store"
   default = "7"

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,9 @@ variable "tags" {
   type    = "map"
   default = {}
 }
+
+variable "rotate_number" {
+  type    = "string"
+  description = "How many Docker Image versions AWS ECR will store"
+  default = "7"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,7 @@ variable "tags" {
   default = {}
 }
 
-variable "max_image_number" {
+variable "max_image_count" {
   type        = "string"
   description = "How many Docker Image versions AWS ECR will store"
   default     = "7"


### PR DESCRIPTION
## what
* Define an `aws_ecr_lifecycle_policy` to expunge old images

## why
* This is a draft version that solves the issue [https://github.com/cloudposse/jenkins/issues/8](https://github.com/cloudposse/jenkins/issues/8).

I do not know your coding patterns, I assumed only untagged for now. However, you can add a ternary to select between tagged/untagged. 

Cheers!