### PR TITLE
Fix Circular Dependency with `aws_iam_policy_document`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ module "ecr" {
 ## Variables
 
 |  Name                        |  Default       |  Description                                                                                             | Required|
-|:----------------------------:|:--------------:|:--------------------------------------------------------------------------------------------------------:|:-------------:|
+|:-----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------|:-------------:|
 | `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`)                                                                    | Yes           |
 | `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
 | `name`                       | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
@@ -46,7 +46,7 @@ module "ecr" {
 ## Outputs
 
 | Name                | Description                                                                             |
-|:-------------------:|:---------------------------------------------------------------------------------------:|
+|:--------------------|:----------------------------------------------------------------------------------------|
 | `registry_id`       | ID of the created AWS Container Registry                                                |
 | `registry_url`      | URL to the created AWS Container Registry                                               |
 | `role_name`         | (Optional) The name of the newly created IAM role that has access to the registry       |

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "token" {
     effect  = "Allow"
     actions = ["ecr:GetAuthorizationToken"]
 
-    resources = ["${aws_ecr_repository.default.arn}"]
+    resources = ["*"]
   }
 }
 


### PR DESCRIPTION
## what
* Changed `resources` of `aws_iam_policy_document` to wildcard

## why
* To prevent data races (https://github.com/cloudposse/terraform-aws-ecr/issues/8) due to circular dependencies
