### PR TITLE
optional tagged and untagged container image lifecycle policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,16 @@ module "ecr" {
 
 ## Variables
 
-|  Name                        |  Default       |  Description                                                                                             | Required|
-|:-----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------|:-------------:|
-| `namespace`                  | `global`       | Namespace (e.g. `cp` or `cloudposse`)                                                                    | Yes           |
-| `stage`                      | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
-| `name`                       | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
-| `roles`                      | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
-| `max_image_count`            | `7`            | How many Docker Image versions AWS ECR will store | Yes |
-
+|  Name                       |  Default       |  Description                                                                                             | Required|
+|:----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------|:-------------:|
+| `namespace`                 | `global`       | Namespace (e.g. `cp` or `cloudposse`)                                                                    | Yes           |
+| `stage`                     | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
+| `name`                      | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
+| `roles`                     | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
+| `create_tagged_lifecycle`   | `false (0)`    | Create a lifecycle policy for tagged Docker Image versions?                                              | No (optional) |
+| `max_tagged_image_count`    | `7`            | How many tagged Docker Image versions AWS ECR will store                                                 | No (optional) |
+| `create_untagged_lifecycle` | `false (0)`    | Create a lifecycle policy for untagged Docker Image versions?                                            | No (optional) |
+| `max_untagged_image_count`  | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | No (optional) |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -34,16 +34,14 @@ module "ecr" {
 
 ## Variables
 
-|  Name                       |  Default       |  Description                                                                                             | Required|
-|:----------------------------|:--------------:|:---------------------------------------------------------------------------------------------------------|:-------------:|
-| `namespace`                 | `global`       | Namespace (e.g. `cp` or `cloudposse`)                                                                    | Yes           |
-| `stage`                     | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
-| `name`                      | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
-| `roles`                     | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
-| `create_tagged_lifecycle`   | `false`        | Create a lifecycle policy for tagged Docker Image versions?                                              | Yes           |
-| `max_tagged_image_count`    | `7`            | How many tagged Docker Image versions AWS ECR will store                                                 | Yes           |
-| `create_untagged_lifecycle` | `false`        | Create a lifecycle policy for untagged Docker Image versions?                                            | Yes           |
-| `max_untagged_image_days`   | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | Yes           |
+|  Name                       |  Default       |  Description                                                                                                  | Required|
+|:----------------------------|:--------------:|:--------------------------------------------------------------------------------------------------------------|:-------------:|
+| `namespace`                 | `global`       | Namespace (e.g. `cp` or `cloudposse`)                                                                         | Yes           |
+| `stage`                     | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                         | Yes           |
+| `name`                      | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                         | Yes           |
+| `roles`                     | `[]`           | List of IAM role names that will be granted permissions to use the container registry                         | No (optional) |
+| `max_tagged_image_count`    | `0`            | How many tagged Docker Image versions AWS ECR will store (tagged images never expire if set to `0`)           | Yes           |
+| `max_untagged_image_days`   | `0`            | Number of days AWS ECR will store untagged Docker Image versions (untagged images never expire if set to `0`) | Yes           |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ module "ecr" {
 | `stage`                     | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
 | `name`                      | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
 | `roles`                     | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
-| `create_tagged_lifecycle`   | `false (0)`    | Create a lifecycle policy for tagged Docker Image versions?                                              | No (optional) |
-| `max_tagged_image_count`    | `7`            | How many tagged Docker Image versions AWS ECR will store                                                 | No (optional) |
-| `create_untagged_lifecycle` | `false (0)`    | Create a lifecycle policy for untagged Docker Image versions?                                            | No (optional) |
-| `max_untagged_image_count`  | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | No (optional) |
+| `create_tagged_lifecycle`   | `false (0)`    | Create a lifecycle policy for tagged Docker Image versions?                                              | Yes           |
+| `max_tagged_image_count`    | `7`            | How many tagged Docker Image versions AWS ECR will store                                                 | Yes           |
+| `create_untagged_lifecycle` | `false (0)`    | Create a lifecycle policy for untagged Docker Image versions?                                            | Yes           |
+| `max_untagged_image_count`  | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | Yes           |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ module "ecr" {
 | `stage`                     | `default`      | Stage (e.g. `prod`, `dev`, `staging`)                                                                    | Yes           |
 | `name`                      | `admin`        | The Name of the application or solution  (e.g. `bastion` or `portal`)                                    | Yes           |
 | `roles`                     | `[]`           | List of IAM role names that will be granted permissions to use the container registry                    | No (optional) |
-| `create_tagged_lifecycle`   | `false (0)`    | Create a lifecycle policy for tagged Docker Image versions?                                              | Yes           |
+| `create_tagged_lifecycle`   | `false`        | Create a lifecycle policy for tagged Docker Image versions?                                              | Yes           |
 | `max_tagged_image_count`    | `7`            | How many tagged Docker Image versions AWS ECR will store                                                 | Yes           |
-| `create_untagged_lifecycle` | `false (0)`    | Create a lifecycle policy for untagged Docker Image versions?                                            | Yes           |
-| `max_untagged_image_count`  | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | Yes           |
+| `create_untagged_lifecycle` | `false`        | Create a lifecycle policy for untagged Docker Image versions?                                            | Yes           |
+| `max_untagged_image_days`   | `14`           | Number of days AWS ECR will store untagged Docker Image versions                                         | Yes           |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_iam_instance_profile" "default" {
 }
 
 resource "aws_ecr_lifecycle_policy" "tagged" {
-  count      = "${var.create_tagged_lifecycle}"
+  count      = "${var.create_tagged_lifecycle == "true" ? 1 : 0}"
   repository = "${aws_ecr_repository.default.name}"
 
   policy = <<EOF
@@ -168,19 +168,19 @@ EOF
 }
 
 resource "aws_ecr_lifecycle_policy" "untagged" {
-  count      = "${var.create_untagged_lifecycle}"
+  count      = "${var.create_untagged_lifecycle == "true" ? 1 : 0}"
   repository = "${aws_ecr_repository.default.name}"
 
   policy = <<EOF
 {
   "rules": [{
     "rulePriority": 2,
-    "description": "Expire images older than ${var.max_untagged_image_count} days",
+    "description": "Expire images older than ${var.max_untagged_image_days} days",
     "selection": {
       "tagStatus": "untagged",
       "countType": "sinceImagePushed",
       "countUnit": "days",
-      "countNumber": ${var.max_untagged_image_count}
+      "countNumber": ${var.max_untagged_image_days}
     },
     "action": {
       "type": "expire"

--- a/main.tf
+++ b/main.tf
@@ -145,7 +145,7 @@ resource "aws_iam_instance_profile" "default" {
 }
 
 resource "aws_ecr_lifecycle_policy" "tagged" {
-  count      = "${var.create_tagged_lifecycle == "true" ? 1 : 0}"
+  count      = "${var.max_tagged_image_count != "0" ? 1 : 0}"
   repository = "${aws_ecr_repository.default.name}"
 
   policy = <<EOF
@@ -168,13 +168,13 @@ EOF
 }
 
 resource "aws_ecr_lifecycle_policy" "untagged" {
-  count      = "${var.create_untagged_lifecycle == "true" ? 1 : 0}"
+  count      = "${var.max_untagged_image_days != "0" ? 1 : 0}"
   repository = "${aws_ecr_repository.default.name}"
 
   policy = <<EOF
 {
   "rules": [{
-    "rulePriority": 2,
+    "rulePriority": 1,
     "description": "Expire images older than ${var.max_untagged_image_days} days",
     "selection": {
       "tagStatus": "untagged",

--- a/variables.tf
+++ b/variables.tf
@@ -25,8 +25,22 @@ variable "tags" {
   default = {}
 }
 
-variable "max_image_count" {
+variable "create_tagged_lifecycle" {
+  default = false
+}
+
+variable "create_untagged_lifecycle" {
+  default = false
+}
+
+variable "max_tagged_image_count" {
   type        = "string"
-  description = "How many Docker Image versions AWS ECR will store"
+  description = "How many tagged Docker Image versions AWS ECR will store"
   default     = "7"
+}
+
+variable "max_untagged_image_count" {
+  type        = "string"
+  description = "Number of days that ECR will store untagged Docker Image versions"
+  default     = "14"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -26,11 +26,11 @@ variable "tags" {
 }
 
 variable "create_tagged_lifecycle" {
-  default = false
+  default = "false"
 }
 
 variable "create_untagged_lifecycle" {
-  default = false
+  default = "false"
 }
 
 variable "max_tagged_image_count" {
@@ -39,7 +39,7 @@ variable "max_tagged_image_count" {
   default     = "7"
 }
 
-variable "max_untagged_image_count" {
+variable "max_untagged_image_days" {
   type        = "string"
   description = "Number of days that ECR will store untagged Docker Image versions"
   default     = "14"

--- a/variables.tf
+++ b/variables.tf
@@ -25,22 +25,16 @@ variable "tags" {
   default = {}
 }
 
-variable "create_tagged_lifecycle" {
-  default = "false"
-}
-
-variable "create_untagged_lifecycle" {
-  default = "false"
-}
-
 variable "max_tagged_image_count" {
   type        = "string"
   description = "How many tagged Docker Image versions AWS ECR will store"
-  default     = "7"
+  default     = "0"
 }
 
 variable "max_untagged_image_days" {
   type        = "string"
   description = "Number of days that ECR will store untagged Docker Image versions"
-  default     = "14"
+  default     = "0"
 }
+
+var


### PR DESCRIPTION
## what
- Introduce option to create lifecycle policy on untagged container images
- By default, do not create any lifecycle policies

## why
- Differentiate between tagged and untagged container image lifecycle policies


## references
Based on the capabilities described here:
https://www.terraform.io/docs/providers/aws/r/ecr_lifecycle_policy.html