### PR TITLE
Replace kops-ecr with ecr (this module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,19 +66,19 @@ module "cicd_user" {
 resource "aws_iam_policy_attachment" "login" {
   name       = "${module.cicd_user.user_name}-login"
   users      = ["${module.cicd_user.user_name}"]
-  policy_arn = "${module.kops_ecr.policy_login_arn}"
+  policy_arn = "${module.ecr.policy_login_arn}"
 }
 
 resource "aws_iam_policy_attachment" "read" {
   name       = "${module.cicd_user.user_name}-read"
   users      = ["${module.cicd_user.user_name}"]
-  policy_arn = "${module.kops_ecr.policy_read_arn}"
+  policy_arn = "${module.ecr.policy_read_arn}"
 }
 
 resource "aws_iam_policy_attachment" "write" {
   name       = "${module.cicd_user.user_name}-write"
   users      = ["${module.cicd_user.user_name}"]
-  policy_arn = "${module.kops_ecr.policy_write_arn}"
+  policy_arn = "${module.ecr.policy_write_arn}"
 }
 ```
 

--- a/README.yaml
+++ b/README.yaml
@@ -81,19 +81,19 @@ usage: |-
   resource "aws_iam_policy_attachment" "login" {
     name       = "${module.cicd_user.user_name}-login"
     users      = ["${module.cicd_user.user_name}"]
-    policy_arn = "${module.kops_ecr.policy_login_arn}"
+    policy_arn = "${module.ecr.policy_login_arn}"
   }
 
   resource "aws_iam_policy_attachment" "read" {
     name       = "${module.cicd_user.user_name}-read"
     users      = ["${module.cicd_user.user_name}"]
-    policy_arn = "${module.kops_ecr.policy_read_arn}"
+    policy_arn = "${module.ecr.policy_read_arn}"
   }
 
   resource "aws_iam_policy_attachment" "write" {
     name       = "${module.cicd_user.user_name}-write"
     users      = ["${module.cicd_user.user_name}"]
-    policy_arn = "${module.kops_ecr.policy_write_arn}"
+    policy_arn = "${module.ecr.policy_write_arn}"
   }
   ```
 


### PR DESCRIPTION
## what
* Rename module reference to `ecr` to match example

## why
* Example refers to a module called `ecr` and not `kops_ecr`
* I'm guessing this got copy pasted from cloudposse/terraform-aws-kops-ecr :)