### PR TITLE
Reinvent permissions to ECR

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ data "aws_iam_policy_document" "resource" {
   count = "${local.principal_non_empty}"
 
   source_json = "${local.principal_read_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
-  override_json_json = "${local.principal_full_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
+  override_json = "${local.principal_full_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
 }
 
 resource "aws_ecr_repository_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
 }
 
 data "aws_iam_role" "read" {
-  count = "${local.roles_non_empty ? local.roles_read_count: 0}"
+  count = "${local.roles_read_non_empty ? local.roles_read_count: 0}"
   name  = "${element(var.roles_readonly, count.index)}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,15 @@
 locals {
-  roles_read_count = "${length(var.roles_readonly)}"
+  roles_read_count     = "${length(var.roles_readonly)}"
   roles_read_non_empty = "${signum(length(var.roles_readonly)) == 1}"
-  roles_read_empty = "${signum(length(var.roles_readonly)) == 0}"
+  roles_read_empty     = "${signum(length(var.roles_readonly)) == 0}"
 
-  roles_full_count = "${length(var.roles)}"
+  roles_full_count     = "${length(var.roles)}"
   roles_full_non_empty = "${signum(length(var.roles)) == 1}"
-  roles_full_empty = "${signum(length(var.roles)) == 0}"
+  roles_full_empty     = "${signum(length(var.roles)) == 0}"
 
-  roles_count = "${length(var.roles_readonly) + length(var.roles)}"
+  roles_count     = "${length(var.roles_readonly) + length(var.roles)}"
   roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 1}"
-  roles_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 0}"
-
+  roles_empty     = "${signum(length(var.roles_readonly) + length(var.roles)) == 0}"
 }
 
 data "aws_iam_role" "read" {
@@ -65,6 +64,7 @@ EOF
 
 data "aws_iam_policy_document" "assume_role" {
   count = "${local.roles_empty}"
+
   statement {
     sid     = "EC2AssumeRole"
     effect  = "Allow"
@@ -126,7 +126,6 @@ resource "aws_ecr_repository_policy" "default_ecr" {
   policy     = "${data.aws_iam_policy_document.default_ecr.json}"
 }
 
-
 ## If any roles provided
 ## Grant access to them
 
@@ -155,7 +154,7 @@ data "aws_iam_policy_document" "resource" {
       "ecr:DescribeImages",
       "ecr:BatchGetImage",
     ]
-  },
+  }
 
   statement {
     sid    = "full"

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ data "aws_iam_policy_document" "empty" {}
 
 data "aws_iam_policy_document" "resource_readonly_access" {
   statement {
-    sid    = "readonly_access"
+    sid    = "ReadonlyAccess"
     effect = "Allow"
 
     principals = {
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "resource_readonly_access" {
 
 data "aws_iam_policy_document" "resource_full_access" {
   statement {
-    sid    = "full_access"
+    sid    = "FullAccess"
     effect = "Allow"
 
     principals = {

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,6 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 
 data "aws_iam_policy_document" "empty" {}
 
-
 data "aws_iam_policy_document" "resource_readonly" {
   statement {
     sid    = "readonly"
@@ -131,7 +130,7 @@ data "aws_iam_policy_document" "resource_readonly" {
       type = "AWS"
 
       identifiers = [
-        "${var.principal_readonly}"
+        "${var.principal_readonly}",
       ]
     }
 
@@ -157,7 +156,7 @@ data "aws_iam_policy_document" "resource_full" {
       type = "AWS"
 
       identifiers = [
-        "${var.principal}"
+        "${var.principal}",
       ]
     }
 
@@ -181,7 +180,7 @@ data "aws_iam_policy_document" "resource_full" {
 data "aws_iam_policy_document" "resource" {
   count = "${local.principal_non_empty}"
 
-  source_json = "${local.principal_read_non_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
+  source_json   = "${local.principal_read_non_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
   override_json = "${local.principal_full_non_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,126 +1,26 @@
-data "aws_iam_role" "default" {
-  count = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
+locals {
+  roles_read_count = "${length(var.roles_readonly)}"
+  roles_read_non_empty = "${signum(length(var.roles_readonly)) == 1}"
+  roles_read_empty = "${signum(length(var.roles_readonly)) == 0}"
+
+  roles_full_count = "${length(var.roles)}"
+  roles_full_non_empty = "${signum(length(var.roles)) == 1}"
+  roles_full_empty = "${signum(length(var.roles)) == 0}"
+
+  roles_count = "${length(var.roles_readonly) + length(var.roles)}"
+  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 1}"
+  roles_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 0}"
+
+}
+
+data "aws_iam_role" "read" {
+  count = "${local.roles_non_empty ? local.roles_read_count: 0}"
+  name  = "${element(var.roles_readonly, count.index)}"
+}
+
+data "aws_iam_role" "full" {
+  count = "${local.roles_full_non_empty ? local.roles_full_count : 0}"
   name  = "${element(var.roles, count.index)}"
-}
-
-data "aws_iam_policy_document" "assume_role" {
-  statement {
-    sid     = "EC2AssumeRole"
-    effect  = "Allow"
-    actions = ["sts:AssumeRole"]
-
-    principals = {
-      type        = "Service"
-      identifiers = ["ec2.amazonaws.com"]
-    }
-  }
-}
-
-data "aws_iam_policy_document" "login" {
-  statement {
-    sid     = "ECRGetAuthorizationToken"
-    effect  = "Allow"
-    actions = ["ecr:GetAuthorizationToken"]
-
-    resources = ["*"]
-  }
-}
-
-data "aws_iam_policy_document" "write" {
-  statement {
-    sid    = "ECRGetAuthorizationToken"
-    effect = "Allow"
-
-    actions = [
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
-    ]
-
-    resources = ["${aws_ecr_repository.default.arn}"]
-  }
-}
-
-data "aws_iam_policy_document" "read" {
-  statement {
-    sid    = "ECRGetAuthorizationToken"
-    effect = "Allow"
-
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-    ]
-
-    resources = ["${aws_ecr_repository.default.arn}"]
-  }
-}
-
-data "aws_iam_policy_document" "default_ecr" {
-  count = "${signum(length(var.roles)) == 1 ? 0 : 1}"
-
-  statement {
-    sid    = "ecr"
-    effect = "Allow"
-
-    principals = {
-      type = "AWS"
-
-      identifiers = [
-        "${aws_iam_role.default.arn}",
-      ]
-    }
-
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-    ]
-  }
-}
-
-data "aws_iam_policy_document" "resource" {
-  count = "${signum(length(var.roles))}"
-
-  statement {
-    sid    = "ecr"
-    effect = "Allow"
-
-    principals = {
-      type = "AWS"
-
-      identifiers = [
-        "${data.aws_iam_role.default.*.arn}",
-      ]
-    }
-
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-    ]
-  }
 }
 
 module "label" {
@@ -135,60 +35,6 @@ module "label" {
 
 resource "aws_ecr_repository" "default" {
   name = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
-}
-
-resource "aws_ecr_repository_policy" "default" {
-  count      = "${signum(length(var.roles))}"
-  repository = "${aws_ecr_repository.default.name}"
-  policy     = "${data.aws_iam_policy_document.resource.json}"
-}
-
-resource "aws_ecr_repository_policy" "default_ecr" {
-  count      = "${signum(length(var.roles)) == 1 ? 0 : 1}"
-  repository = "${aws_ecr_repository.default.name}"
-  policy     = "${data.aws_iam_policy_document.default_ecr.json}"
-}
-
-resource "aws_iam_policy" "login" {
-  name        = "${module.label.id}${var.delimiter}login"
-  description = "Allow IAM Users to call ecr:GetAuthorizationToken"
-  policy      = "${data.aws_iam_policy_document.login.json}"
-}
-
-resource "aws_iam_policy" "read" {
-  name        = "${module.label.id}${var.delimiter}read"
-  description = "Allow IAM Users to pull from ECR"
-  policy      = "${data.aws_iam_policy_document.read.json}"
-}
-
-resource "aws_iam_policy" "write" {
-  name        = "${module.label.id}${var.delimiter}write"
-  description = "Allow IAM Users to push into ECR"
-  policy      = "${data.aws_iam_policy_document.write.json}"
-}
-
-resource "aws_iam_role" "default" {
-  count              = "${signum(length(var.roles)) == 1 ? 0 : 1}"
-  name               = "${module.label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-}
-
-resource "aws_iam_role_policy_attachment" "default_ecr" {
-  count      = "${signum(length(var.roles)) == 1 ? 0 : 1}"
-  role       = "${aws_iam_role.default.name}"
-  policy_arn = "${aws_iam_policy.login.arn}"
-}
-
-resource "aws_iam_role_policy_attachment" "default" {
-  count      = "${signum(length(var.roles)) == 1 ? length(var.roles) : 0}"
-  role       = "${element(var.roles, count.index)}"
-  policy_arn = "${aws_iam_policy.login.arn}"
-}
-
-resource "aws_iam_instance_profile" "default" {
-  count = "${signum(length(var.roles)) == 1 ? 0 : 1}"
-  name  = "${module.label.id}"
-  role  = "${aws_iam_role.default.name}"
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {
@@ -211,4 +57,137 @@ resource "aws_ecr_lifecycle_policy" "default" {
   }]
 }
 EOF
+}
+
+## If roles are empty
+## Create default role to provide full access.
+## The role can be attached or assumed
+
+data "aws_iam_policy_document" "assume_role" {
+  count = "${local.roles_empty}"
+  statement {
+    sid     = "EC2AssumeRole"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals = {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "default" {
+  count              = "${local.roles_empty}"
+  name               = "${module.label.id}"
+  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
+}
+
+resource "aws_iam_instance_profile" "default" {
+  count = "${local.roles_empty}"
+  name  = "${module.label.id}"
+  role  = "${aws_iam_role.default.name}"
+}
+
+## Grant access to default role
+data "aws_iam_policy_document" "default_ecr" {
+  count = "${local.roles_empty}"
+
+  statement {
+    sid    = "ecr"
+    effect = "Allow"
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "${aws_iam_role.default.arn}",
+      ]
+    }
+
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "default_ecr" {
+  count      = "${local.roles_empty}"
+  repository = "${aws_ecr_repository.default.name}"
+  policy     = "${data.aws_iam_policy_document.default_ecr.json}"
+}
+
+
+## If any roles provided
+## Grant access to them
+
+data "aws_iam_policy_document" "resource" {
+  count = "${local.roles_non_empty}"
+
+  statement {
+    sid    = "readonly"
+    effect = "Allow"
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "${data.aws_iam_role.read.*.arn}",
+      ]
+    }
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+    ]
+  },
+
+  statement {
+    sid    = "full"
+    effect = "Allow"
+
+    principals = {
+      type = "AWS"
+
+      identifiers = [
+        "${data.aws_iam_role.full.*.arn}",
+      ]
+    }
+
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "default" {
+  count      = "${local.roles_non_empty}"
+  repository = "${aws_ecr_repository.default.name}"
+  policy     = "${data.aws_iam_policy_document.resource.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -119,8 +119,8 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 ## If any roles provided
 ## Grant access to them
 
-data "aws_iam_policy_document" "resource_readonly" {
-  count = "${local.principal_read_non_empty}"
+data "aws_iam_policy_document" "resource" {
+  count = "${local.principal_non_empty}"
 
   statement {
     sid    = "readonly"
@@ -130,7 +130,7 @@ data "aws_iam_policy_document" "resource_readonly" {
       type = "AWS"
 
       identifiers = [
-        "${var.principal_readonly}",
+        "${var.principal_readonly}"
       ]
     }
 
@@ -145,17 +145,6 @@ data "aws_iam_policy_document" "resource_readonly" {
       "ecr:BatchGetImage",
     ]
   }
-}
-
-resource "aws_ecr_repository_policy" "default_readonly" {
-  count      = "${local.principal_read_non_empty}"
-  repository = "${aws_ecr_repository.default.name}"
-  policy     = "${data.aws_iam_policy_document.resource_readonly.json}"
-}
-
-
-data "aws_iam_policy_document" "resource" {
-  count = "${local.principal_full_non_empty}"
 
   statement {
     sid    = "full"
@@ -165,7 +154,7 @@ data "aws_iam_policy_document" "resource" {
       type = "AWS"
 
       identifiers = [
-        "${var.principal}",
+        "${var.principal}"
       ]
     }
 
@@ -187,7 +176,7 @@ data "aws_iam_policy_document" "resource" {
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  count      = "${local.principal_full_non_empty}"
+  count      = "${local.principal_non_empty}"
   repository = "${aws_ecr_repository.default.name}"
   policy     = "${data.aws_iam_policy_document.resource.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   principals_readonly_access_count     = "${length(var.principals_readonly_access)}"
-  principal_readonly_access_non_empty = "${signum(length(var.principals_readonly_access))}"
+  principals_readonly_access_non_empty = "${signum(length(var.principals_readonly_access))}"
   principals_readonly_access_empty     = "${signum(length(var.principals_readonly_access)) == 0 ? 1 : 0}"
 
   principals_full_access_count     = "${length(var.principals_full_access)}"
@@ -130,7 +130,7 @@ data "aws_iam_policy_document" "resource_readonly_access" {
       type = "AWS"
 
       identifiers = [
-        "${var.principal_readonly_access}",
+        "${var.principals_readonly_access}",
       ]
     }
 
@@ -178,9 +178,9 @@ data "aws_iam_policy_document" "resource_full_access" {
 }
 
 data "aws_iam_policy_document" "resource" {
-  count = "${local.principal_non_empty}"
+  count = "${local.principals_total_non_empty}"
 
-  source_json   = "${local.principals_read_access_non_empty ? data.aws_iam_policy_document.resource_readonly_access.json : data.aws_iam_policy_document.empty.json}"
+  source_json   = "${local.principals_readonly_access_non_empty ? data.aws_iam_policy_document.resource_readonly_access.json : data.aws_iam_policy_document.empty.json}"
   override_json = "${local.principals_full_access_non_empty ? data.aws_iam_policy_document.resource_full_access.json : data.aws_iam_policy_document.empty.json}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ data "aws_iam_policy_document" "default_ecr" {
   count = "${local.principals_total_empty}"
 
   statement {
-    sid    = "ecr"
+    sid    = "ECR"
     effect = "Allow"
 
     principals = {

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,15 @@
 locals {
   roles_read_count     = "${length(var.roles_readonly)}"
-  roles_read_non_empty = "${signum(length(var.roles_readonly)) == 1}"
-  roles_read_empty     = "${signum(length(var.roles_readonly)) == 0}"
+  roles_read_non_empty = "${signum(length(var.roles_readonly))}"
+  roles_read_empty     = "${signum(length(var.roles_readonly)) == 0 ? 1 : 0}"
 
   roles_full_count     = "${length(var.roles)}"
-  roles_full_non_empty = "${signum(length(var.roles)) == 1}"
-  roles_full_empty     = "${signum(length(var.roles)) == 0}"
+  roles_full_non_empty = "${signum(length(var.roles))}"
+  roles_full_empty     = "${signum(length(var.roles)) == 0 ? 1 : 0}"
 
   roles_count     = "${length(var.roles_readonly) + length(var.roles)}"
-  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 1}"
-  roles_empty     = "${signum(length(var.roles_readonly) + length(var.roles)) == 0}"
+  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles))}"
+  roles_empty     = "${signum(length(var.roles_readonly) + length(var.roles)) == 0 ? 1 : 0}"
 }
 
 data "aws_iam_role" "read" {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   roles_full_empty     = "${signum(length(var.roles)) == 0 ? 1 : 0}"
 
   roles_count     = "${length(var.roles_readonly) + length(var.roles)}"
-  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles))}"
+  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 0 ? 0 : 1}"
   roles_empty     = "${signum(length(var.roles_readonly) + length(var.roles)) == 0 ? 1 : 0}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -119,8 +119,11 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 ## If any roles provided
 ## Grant access to them
 
-data "aws_iam_policy_document" "resource" {
-  count = "${local.principal_non_empty}"
+data "aws_iam_policy_document" "empty" {}
+
+
+data "aws_iam_policy_document" "resource_readonly" {
+  count = "${local.principal_read_non_empty}"
 
   statement {
     sid    = "readonly"
@@ -145,6 +148,17 @@ data "aws_iam_policy_document" "resource" {
       "ecr:BatchGetImage",
     ]
   }
+}
+
+resource "aws_ecr_repository_policy" "default_readonly" {
+  count      = "${local.principal_read_non_empty}"
+  repository = "${aws_ecr_repository.default.name}"
+  policy     = "${data.aws_iam_policy_document.resource_readonly.json}"
+}
+
+
+data "aws_iam_policy_document" "resource_full" {
+  count = "${local.principal_full_non_empty}"
 
   statement {
     sid    = "full"
@@ -173,6 +187,13 @@ data "aws_iam_policy_document" "resource" {
       "ecr:BatchGetImage",
     ]
   }
+}
+
+data "aws_iam_policy_document" "resource" {
+  count = "${local.principal_non_empty}"
+
+  source_json = "${local.principal_read_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
+  override_json_json = "${local.principal_full_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
 }
 
 resource "aws_ecr_repository_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,19 @@
 locals {
-  principal_read_count     = "${length(var.principal_readonly)}"
-  principal_read_non_empty = "${signum(length(var.principal_readonly))}"
-  principal_read_empty     = "${signum(length(var.principal_readonly)) == 0 ? 1 : 0}"
+  principals_readonly_access_count     = "${length(var.principals_readonly_access)}"
+  principal_readonly_access_non_empty = "${signum(length(var.principals_readonly_access))}"
+  principals_readonly_access_empty     = "${signum(length(var.principals_readonly_access)) == 0 ? 1 : 0}"
 
-  principal_full_count     = "${length(var.principal)}"
-  principal_full_non_empty = "${signum(length(var.principal))}"
-  principal_full_empty     = "${signum(length(var.principal)) == 0 ? 1 : 0}"
+  principals_full_access_count     = "${length(var.principals_full_access)}"
+  principals_full_access_non_empty = "${signum(length(var.principals_full_access))}"
+  principals_full_access_empty     = "${signum(length(var.principals_full_access)) == 0 ? 1 : 0}"
 
-  principal_count     = "${length(var.principal_readonly) + length(var.principal)}"
-  principal_non_empty = "${signum(length(var.principal_readonly) + length(var.principal))}"
-  principal_empty     = "${signum(length(var.principal_readonly) + length(var.principal)) == 0 ? 1 : 0}"
+  principals_total_count     = "${length(var.principals_readonly_access) + length(var.principals_full_access)}"
+  principals_total_non_empty = "${signum(length(var.principals_readonly_access) + length(var.principals_full_access))}"
+  principals_total_empty     = "${signum(length(var.principals_readonly_access) + length(var.principals_full_access)) == 0 ? 1 : 0}"
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -53,7 +53,7 @@ EOF
 ## The role can be attached or assumed
 
 data "aws_iam_policy_document" "assume_role" {
-  count = "${local.principal_empty}"
+  count = "${local.principals_total_empty}"
 
   statement {
     sid     = "EC2AssumeRole"
@@ -68,20 +68,20 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "default" {
-  count              = "${local.principal_empty}"
+  count              = "${local.principals_total_empty}"
   name               = "${module.label.id}"
   assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
 }
 
 resource "aws_iam_instance_profile" "default" {
-  count = "${local.principal_empty}"
+  count = "${local.principals_total_empty}"
   name  = "${module.label.id}"
   role  = "${aws_iam_role.default.name}"
 }
 
 ## Grant access to default role
 data "aws_iam_policy_document" "default_ecr" {
-  count = "${local.principal_empty}"
+  count = "${local.principals_total_empty}"
 
   statement {
     sid    = "ecr"
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "default_ecr" {
 }
 
 resource "aws_ecr_repository_policy" "default_ecr" {
-  count      = "${local.principal_empty}"
+  count      = "${local.principals_total_empty}"
   repository = "${aws_ecr_repository.default.name}"
   policy     = "${data.aws_iam_policy_document.default_ecr.json}"
 }
@@ -121,16 +121,16 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 
 data "aws_iam_policy_document" "empty" {}
 
-data "aws_iam_policy_document" "resource_readonly" {
+data "aws_iam_policy_document" "resource_readonly_access" {
   statement {
-    sid    = "readonly"
+    sid    = "readonly_access"
     effect = "Allow"
 
     principals = {
       type = "AWS"
 
       identifiers = [
-        "${var.principal_readonly}",
+        "${var.principal_readonly_access}",
       ]
     }
 
@@ -147,16 +147,16 @@ data "aws_iam_policy_document" "resource_readonly" {
   }
 }
 
-data "aws_iam_policy_document" "resource_full" {
+data "aws_iam_policy_document" "resource_full_access" {
   statement {
-    sid    = "full"
+    sid    = "full_access"
     effect = "Allow"
 
     principals = {
       type = "AWS"
 
       identifiers = [
-        "${var.principal}",
+        "${var.principals_full_access}",
       ]
     }
 
@@ -180,12 +180,12 @@ data "aws_iam_policy_document" "resource_full" {
 data "aws_iam_policy_document" "resource" {
   count = "${local.principal_non_empty}"
 
-  source_json   = "${local.principal_read_non_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
-  override_json = "${local.principal_full_non_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
+  source_json   = "${local.principals_read_access_non_empty ? data.aws_iam_policy_document.resource_readonly_access.json : data.aws_iam_policy_document.empty.json}"
+  override_json = "${local.principals_full_access_non_empty ? data.aws_iam_policy_document.resource_full_access.json : data.aws_iam_policy_document.empty.json}"
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  count      = "${local.principal_non_empty}"
+  count      = "${local.principals_total_non_empty}"
   repository = "${aws_ecr_repository.default.name}"
   policy     = "${data.aws_iam_policy_document.resource.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -123,8 +123,6 @@ data "aws_iam_policy_document" "empty" {}
 
 
 data "aws_iam_policy_document" "resource_readonly" {
-  count = "${local.principal_read_non_empty}"
-
   statement {
     sid    = "readonly"
     effect = "Allow"
@@ -150,16 +148,7 @@ data "aws_iam_policy_document" "resource_readonly" {
   }
 }
 
-resource "aws_ecr_repository_policy" "default_readonly" {
-  count      = "${local.principal_read_non_empty}"
-  repository = "${aws_ecr_repository.default.name}"
-  policy     = "${data.aws_iam_policy_document.resource_readonly.json}"
-}
-
-
 data "aws_iam_policy_document" "resource_full" {
-  count = "${local.principal_full_non_empty}"
-
   statement {
     sid    = "full"
     effect = "Allow"

--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ data "aws_iam_policy_document" "resource" {
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  count      = "${local.roles_non_empty}"
+  count      = "${local.roles_full_non_empty}"
   repository = "${aws_ecr_repository.default.name}"
   policy     = "${data.aws_iam_policy_document.resource.json}"
 }

--- a/main.tf
+++ b/main.tf
@@ -181,8 +181,8 @@ data "aws_iam_policy_document" "resource_full" {
 data "aws_iam_policy_document" "resource" {
   count = "${local.principal_non_empty}"
 
-  source_json = "${local.principal_read_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
-  override_json = "${local.principal_full_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
+  source_json = "${local.principal_read_non_empty ? data.aws_iam_policy_document.resource_readonly.json : data.aws_iam_policy_document.empty.json}"
+  override_json = "${local.principal_full_non_empty ? data.aws_iam_policy_document.resource_full.json : data.aws_iam_policy_document.empty.json}"
 }
 
 resource "aws_ecr_repository_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   roles_full_empty     = "${signum(length(var.roles)) == 0 ? 1 : 0}"
 
   roles_count     = "${length(var.roles_readonly) + length(var.roles)}"
-  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles)) == 0 ? 0 : 1}"
+  roles_non_empty = "${signum(length(var.roles_readonly) + length(var.roles))}"
   roles_empty     = "${signum(length(var.roles_readonly) + length(var.roles)) == 0 ? 1 : 0}"
 }
 
@@ -129,8 +129,8 @@ resource "aws_ecr_repository_policy" "default_ecr" {
 ## If any roles provided
 ## Grant access to them
 
-data "aws_iam_policy_document" "resource" {
-  count = "${local.roles_non_empty}"
+data "aws_iam_policy_document" "resource_readonly" {
+  count = "${local.roles_read_non_empty}"
 
   statement {
     sid    = "readonly"
@@ -155,6 +155,17 @@ data "aws_iam_policy_document" "resource" {
       "ecr:BatchGetImage",
     ]
   }
+}
+
+resource "aws_ecr_repository_policy" "default_readonly" {
+  count      = "${local.roles_read_non_empty}"
+  repository = "${aws_ecr_repository.default.name}"
+  policy     = "${data.aws_iam_policy_document.resource_readonly.json}"
+}
+
+
+data "aws_iam_policy_document" "resource" {
+  count = "${local.roles_full_count}"
 
   statement {
     sid    = "full"

--- a/main.tf
+++ b/main.tf
@@ -165,7 +165,7 @@ resource "aws_ecr_repository_policy" "default_readonly" {
 
 
 data "aws_iam_policy_document" "resource" {
-  count = "${local.roles_full_count}"
+  count = "${local.roles_full_non_empty}"
 
   statement {
     sid    = "full"

--- a/output.tf
+++ b/output.tf
@@ -22,33 +22,3 @@ output "role_arn" {
   value       = "${join("", aws_iam_role.default.*.arn)}"
   description = "Assume Role ARN to get registry access"
 }
-
-output "policy_login_name" {
-  value       = "${aws_iam_policy.login.name}"
-  description = "The IAM Policy name to be given access to login in ECR"
-}
-
-output "policy_login_arn" {
-  value       = "${aws_iam_policy.login.arn}"
-  description = "The IAM Policy ARN to be given access to login in ECR"
-}
-
-output "policy_read_name" {
-  value       = "${aws_iam_policy.read.name}"
-  description = "The IAM Policy name to be given access to pull images from ECR"
-}
-
-output "policy_read_arn" {
-  value       = "${aws_iam_policy.read.arn}"
-  description = "The IAM Policy ARN to be given access to pull images from ECR"
-}
-
-output "policy_write_name" {
-  value       = "${aws_iam_policy.write.name}"
-  description = "The IAM Policy name to be given access to push images to ECR"
-}
-
-output "policy_write_arn" {
-  value       = "${aws_iam_policy.write.arn}"
-  description = "The IAM Policy ARN to be given access to push images to ECR"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -16,13 +16,13 @@ variable "use_fullname" {
   description = "Set 'true' to use `namespace-stage-name` for ecr repository name, else `name`"
 }
 
-variable "principal" {
+variable "principals_full_access" {
   type        = "list"
   description = "Principal ARN to provide with full access to the ECR"
   default     = []
 }
 
-variable "principal_readonly" {
+variable "principals_readonly_access" {
   type        = "list"
   description = "Principal ARN to provide with readonly access to the ECR"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,13 @@ variable "use_fullname" {
 
 variable "roles" {
   type        = "list"
-  description = "Principal IAM roles to provide with access to the ECR"
+  description = "Principal IAM roles to provide with full access to the ECR"
+  default     = []
+}
+
+variable "roles_readonly" {
+  type        = "list"
+  description = "Principal IAM roles to provide with readonly access to the ECR"
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,15 +16,15 @@ variable "use_fullname" {
   description = "Set 'true' to use `namespace-stage-name` for ecr repository name, else `name`"
 }
 
-variable "roles" {
+variable "principal" {
   type        = "list"
-  description = "Principal IAM roles to provide with full access to the ECR"
+  description = "Principal ARN to provide with full access to the ECR"
   default     = []
 }
 
-variable "roles_readonly" {
+variable "principal_readonly" {
   type        = "list"
-  description = "Principal IAM roles to provide with readonly access to the ECR"
+  description = "Principal ARN to provide with readonly access to the ECR"
   default     = []
 }
 


### PR DESCRIPTION
## What
* Grant permission to access ECR using ECR policy with principal that have access to it. Basically, let ECR describe who can access it, rather than each user/role listing the modules they can access

## Why
* To solve IAM limit problem (more scalable strategy and probably the way we should have done it from the get go)

## Breaking changes
* Variable `roles` replaced with `principals_full_access` or `principals_readonly_access` and expects list or role\user arns as value
* We removed policies that provide access to the registry. (`policy_login_name`, `policy_login_arn`, `policy_read_name`, `policy_read_arn`, `policy_write_name`, `policy_write_arn`).
So you do not need to attach the policies to IAM role\user. Please provide IAM role\user arn as variable `principals_full_access` or `principals_readonly_access` depend on what type of access to you need.

Example:


```
module "kops_ecr" {
  source       = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.2.11"
  name         = "${var.name}"
  namespace    = "${var.namespace}"
  stage        = "${var.stage}"
  use_fullname = "${var.use_fullname}"

  roles = [
    "${module.kops_metadata.masters_role_name}",
    "${module.kops_metadata.nodes_role_name}",
  ]
}

resource "aws_iam_policy_attachment" "login" {
  count      = "${signum(length(var.users))}"
  name       = "${module.label.id}"
  users      = ["${var.users}"]
  policy_arn = "${module.kops_ecr.policy_login_arn}"
}

```

now should be 

```
module "kops_ecr" {
  source       = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.3.0"
  name         = "${var.name}"
  namespace    = "${var.namespace}"
  stage        = "${var.stage}"
  use_fullname = "${var.use_fullname}"

  principals_readonly_access = [
    "${module.kops_metadata.masters_role_arn}",
    "${module.kops_metadata.nodes_role_arn}",
  ]

  principals_full_access =  [
    "${var.users_arns}"
  ]
}

```
