### PR TITLE
Add the tags variable to the ECR repository object

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ module "label" {
 resource "aws_ecr_repository" "default" {
   count = "${var.enabled == "true" ? 1 : 0}"
   name  = "${var.use_fullname == "true" ? module.label.id : module.label.name}"
+  tags  = "${module.label.tags}"
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {


### PR DESCRIPTION
## What
This passes through the existing tags variable to the ECR resource
so that the repository is tagged with any user requested settings.

## Why
Add support for tagging of ECR repositories with user provided metadata