### PR TITLE
fix: Unquote "statement" argument for resource "aws_iam_policy_document"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,7 +118,7 @@ data "aws_iam_policy_document" "resource_full_access" {
 data "aws_iam_policy_document" "resource" {
   source_json   = "${local.principals_readonly_access_non_empty ? data.aws_iam_policy_document.resource_readonly_access.json : data.aws_iam_policy_document.empty.json}"
   override_json = "${local.principals_full_access_non_empty ? data.aws_iam_policy_document.resource_full_access.json : data.aws_iam_policy_document.empty.json}"
-  "statement"   = []
+  statement     = []
 }
 
 resource "aws_ecr_repository_policy" "default" {


### PR DESCRIPTION
Terraform 0.12 throws error:

```
Error: Invalid argument name

  on .terraform/modules/xxxx/main.tf line 121, in data "aws_iam_policy_document" "resource":
 121:   "statement"   = []

Argument names must not be quoted.
```