### PR TITLE
Update terraform-null-label to v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,15 +252,15 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|---|---|
 
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [s2504s_homepage]: https://github.com/s2504s
-  [s2504s_avatar]: https://github.com/s2504s.png?size=150
+  [s2504s_avatar]: https://img.cloudposse.com/150x150/https://github.com/s2504s.png
   [ivan-pinatti_homepage]: https://github.com/ivan-pinatti
-  [ivan-pinatti_avatar]: https://github.com/ivan-pinatti.png?size=150
+  [ivan-pinatti_avatar]: https://img.cloudposse.com/150x150/https://github.com/ivan-pinatti.png
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "resource_readonly_access" {
   count = var.enabled ? 1 : 0
 
   statement {
-    sid = "ReadonlyAccess"
+    sid    = "ReadonlyAccess"
     effect = "Allow"
 
     principals {
@@ -91,7 +91,7 @@ data "aws_iam_policy_document" "resource_full_access" {
   count = var.enabled ? 1 : 0
 
   statement {
-    sid = "FullAccess"
+    sid    = "FullAccess"
     effect = "Allow"
 
     principals {
@@ -118,13 +118,13 @@ data "aws_iam_policy_document" "resource_full_access" {
 }
 
 data "aws_iam_policy_document" "resource" {
-  count = var.enabled ? 1 : 0
-  source_json = local.principals_readonly_access_non_empty ? join("", data.aws_iam_policy_document.resource_readonly_access.*.json) : join("", data.aws_iam_policy_document.empty.*.json)
+  count         = var.enabled ? 1 : 0
+  source_json   = local.principals_readonly_access_non_empty ? join("", data.aws_iam_policy_document.resource_readonly_access.*.json) : join("", data.aws_iam_policy_document.empty.*.json)
   override_json = local.principals_full_access_non_empty ? join("", data.aws_iam_policy_document.resource_full_access.*.json) : join("", data.aws_iam_policy_document.empty.*.json)
 }
 
 resource "aws_ecr_repository_policy" "default" {
-  count = local.ecr_need_policy && var.enabled ? 1 : 0
+  count      = local.ecr_need_policy && var.enabled ? 1 : 0
   repository = join("", aws_ecr_repository.default.*.name)
-  policy = join("", data.aws_iam_policy_document.resource.*.json)
+  policy     = join("", data.aws_iam_policy_document.resource.*.json)
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
   enabled    = var.enabled
   namespace  = var.namespace
   stage      = var.stage

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,5 @@ terraform {
     aws      = "~> 2.0"
     template = "~> 2.0"
     local    = "~> 1.2"
-    null     = "~> 2.0"
   }
 }


### PR DESCRIPTION
Since `null_resource` was dropped in the `terraform-null-label` module starting version [0.15.0](https://github.com/cloudposse/terraform-null-label/releases/tag/0.15.0) and the code was completely removed in the recent version [0.16.0](https://github.com/cloudposse/terraform-null-label/releases/tag/0.16.0), it looks ok to update the `terraform-null-label` to the recent version.