### PR TITLE
Add ImageScan actions to iam roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "resource_readonly_access" {
       "ecr:ListImages",
       "ecr:DescribeImages",
       "ecr:BatchGetImage",
+      "ecr:DescribeImageScanFindings",
     ]
   }
 }
@@ -119,6 +120,8 @@ data "aws_iam_policy_document" "resource_full_access" {
       "ecr:ListImages",
       "ecr:DescribeImages",
       "ecr:BatchGetImage",
+      "ecr:DescribeImageScanFindings",
+      "ecr:StartImageScan",
     ]
   }
 }


### PR DESCRIPTION
This allows ReadOnly to call DescribeImageScanFindings and FullAccess to call DescribeImageScanFindings & StartImageScan