### PR TITLE
enhancement for multiple repo creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Available targets:
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| list_image | list of docker local image name, used as a repositry name for AWS-ECR | list(string) | `<list>` | no |
+| image_names | List of Docker local image names, used as repository names for AWS ECR | list(string) | `<list>` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -153,10 +153,10 @@ Available targets:
 | registry_id | Registry ID |
 | registry_url | Registry URL |
 | repository_arn | Repository ARN |
-| repository_arn_map | Repository arn map |
-| repository_id_map | Repository id map |
+| repository_arn_map | Map of repository names to repository ARNs |
+| repository_id_map | Map of repository names to repository IDs |
 | repository_name | Repository name |
-| repository_url_map | Repository url map |
+| repository_url_map | Map of repository names to repository URLs |
 
 
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Available targets:
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
+| list_image | list of docker local image name, used as a repositry name for AWS-ECR | list(string) | `<list>` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -152,7 +153,10 @@ Available targets:
 | registry_id | Registry ID |
 | registry_url | Registry URL |
 | repository_arn | Repository ARN |
+| repository_arn_map | Repository arn map |
+| repository_id_map | Repository id map |
 | repository_name | Repository name |
+| repository_url_map | Repository url map |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,7 +5,7 @@
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| list_image | list of docker local image name, used as a repositry name for AWS-ECR | list(string) | `<list>` | no |
+| image_names | List of Docker local image names, used as repository names for AWS ECR | list(string) | `<list>` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -24,8 +24,8 @@
 | registry_id | Registry ID |
 | registry_url | Registry URL |
 | repository_arn | Repository ARN |
-| repository_arn_map | Repository arn map |
-| repository_id_map | Repository id map |
+| repository_arn_map | Map of repository names to repository ARNs |
+| repository_id_map | Map of repository names to repository IDs |
 | repository_name | Repository name |
-| repository_url_map | Repository url map |
+| repository_url_map | Map of repository names to repository URLs |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,6 +5,7 @@
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
+| list_image | list of docker local image name, used as a repositry name for AWS-ECR | list(string) | `<list>` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -23,5 +24,8 @@
 | registry_id | Registry ID |
 | registry_url | Registry URL |
 | repository_arn | Repository ARN |
+| repository_arn_map | Repository arn map |
+| repository_id_map | Repository id map |
 | repository_name | Repository name |
+| repository_url_map | Repository url map |
 

--- a/examples/multiple-repo/main.tf
+++ b/examples/multiple-repo/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.region
+  region = "eu-west-1"
 }
 
 module "ecr" {

--- a/examples/multiple-repo/main.tf
+++ b/examples/multiple-repo/main.tf
@@ -3,10 +3,10 @@ provider "aws" {
 }
 
 module "ecr" {
-  source    = "../../"
-  namespace = "eg"
-  stage     = "dev"
-  name      = "app"
+  source       = "../../"
+  namespace    = "eg"
+  stage        = "dev"
+  name         = "app"
   use_fullname = false
-  list_image = ["redis", "nginx"]
+  list_image   = ["redis", "nginx"]
 }

--- a/examples/multiple-repo/main.tf
+++ b/examples/multiple-repo/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.region
+}
+
+module "ecr" {
+  source    = "../../"
+  namespace = "eg"
+  stage     = "dev"
+  name      = "app"
+  use_fullname = false
+  list_image = ["redis", "nginx"]
+}

--- a/examples/multiple-repo/outputs.tf
+++ b/examples/multiple-repo/outputs.tf
@@ -1,0 +1,8 @@
+output "repository_id_map" {
+  value       = module.ecr.repository_id_map
+  description = "Repository id map"
+}
+output "repository_url_map" {
+  value       = module.ecr.repository_url_map
+  description = "Repository url map"
+}

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_ecr_repository" "default" {
 
 resource "aws_ecr_lifecycle_policy" "default" {
   count      = var.enabled ? length(local.image_names) : 0
-  repository = join("", [aws_ecr_repository.default[count.index].name])
+  repository = aws_ecr_repository.default[count.index].name
 
   policy = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "label" {
 }
 
 locals {
-  _name  = var.use_fullname ? module.label.id : module.label.name
+  _name      = var.use_fullname ? module.label.id : module.label.name
   list_image = length(var.list_image) > 0 ? var.list_image : [local._name]
 }
 
@@ -34,7 +34,7 @@ resource "aws_ecr_repository" "default" {
 
 resource "aws_ecr_lifecycle_policy" "default" {
   count      = var.enabled ? length(local.list_image) : 0
-  repository = join("", [aws_ecr_repository.default[count.index].name] )
+  repository = join("", [aws_ecr_repository.default[count.index].name])
 
   policy = <<EOF
 {

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "label" {
 }
 
 locals {
-  _name      = var.use_fullname ? module.label.id : module.label.name
+  _name       = var.use_fullname ? module.label.id : module.label.name
   image_names = length(var.image_names) > 0 ? var.image_names : [local._name]
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,18 +18,26 @@ output "repository_arn" {
   description = "Repository ARN"
 }
 
-
 output "repository_id_map" {
   value       = zipmap(
-        aws_ecr_repository.default[*].name
-        ,aws_ecr_repository.default[*].registry_id
-    )
+                    aws_ecr_repository.default[*].name
+                    ,aws_ecr_repository.default[*].registry_id
+                )
   description = "Repository id map"
 }
+
 output "repository_url_map" {
   value       = zipmap(
-        aws_ecr_repository.default[*].name
-        ,aws_ecr_repository.default[*].repository_url
-    )
+                    aws_ecr_repository.default[*].name
+                    ,aws_ecr_repository.default[*].repository_url
+                )
   description = "Repository url map"
+}
+
+output "repository_arn_map" {
+  value       = zipmap(
+                    aws_ecr_repository.default[*].name
+                    ,aws_ecr_repository.default[*].arn
+                )
+  description = "Repository arn map"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,25 +19,25 @@ output "repository_arn" {
 }
 
 output "repository_id_map" {
-  value       = zipmap(
-                    aws_ecr_repository.default[*].name
-                    ,aws_ecr_repository.default[*].registry_id
-                )
+  value = zipmap(
+    aws_ecr_repository.default[*].name
+    , aws_ecr_repository.default[*].registry_id
+  )
   description = "Repository id map"
 }
 
 output "repository_url_map" {
-  value       = zipmap(
-                    aws_ecr_repository.default[*].name
-                    ,aws_ecr_repository.default[*].repository_url
-                )
+  value = zipmap(
+    aws_ecr_repository.default[*].name
+    , aws_ecr_repository.default[*].repository_url
+  )
   description = "Repository url map"
 }
 
 output "repository_arn_map" {
-  value       = zipmap(
-                    aws_ecr_repository.default[*].name
-                    ,aws_ecr_repository.default[*].arn
-                )
+  value = zipmap(
+    aws_ecr_repository.default[*].name
+    , aws_ecr_repository.default[*].arn
+  )
   description = "Repository arn map"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,19 @@ output "repository_arn" {
   value       = join("", aws_ecr_repository.default.*.arn)
   description = "Repository ARN"
 }
+
+
+output "repository_id_map" {
+  value       = zipmap(
+        aws_ecr_repository.default[*].name
+        ,aws_ecr_repository.default[*].registry_id
+    )
+  description = "Repository id map"
+}
+output "repository_url_map" {
+  value       = zipmap(
+        aws_ecr_repository.default[*].name
+        ,aws_ecr_repository.default[*].repository_url
+    )
+  description = "Repository url map"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,21 +23,21 @@ output "repository_id_map" {
     aws_ecr_repository.default[*].name
     , aws_ecr_repository.default[*].registry_id
   )
-  description = "Repository id map"
+  description = "Map of repository names to repository IDs"
 }
 
 output "repository_url_map" {
   value = zipmap(
-    aws_ecr_repository.default[*].name
-    , aws_ecr_repository.default[*].repository_url
+    aws_ecr_repository.default[*].name,
+    aws_ecr_repository.default[*].repository_url
   )
-  description = "Repository url map"
+  description = "Map of repository names to repository URLs"
 }
 
 output "repository_arn_map" {
   value = zipmap(
-    aws_ecr_repository.default[*].name
-    , aws_ecr_repository.default[*].arn
+    aws_ecr_repository.default[*].name,
+    aws_ecr_repository.default[*].arn
   )
-  description = "Repository arn map"
+  description = "Map of repository names to repository ARNs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "regex_replace_chars" {
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
 
-variable "list_image" {
+variable "image_names" {
   type        = list(string)
   default     = []
   description = "List of Docker local image names, used as repository names for AWS ECR "

--- a/variables.tf
+++ b/variables.tf
@@ -74,3 +74,8 @@ variable "regex_replace_chars" {
   description = "Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only hyphens, letters and digits are allowed, all other chars are removed"
 }
 
+variable "list_image" {
+  type        = list(string)
+  default     = []
+  description = "list of docker local image name, used as a repositry name for AWS-ECR "
+}

--- a/variables.tf
+++ b/variables.tf
@@ -77,5 +77,5 @@ variable "regex_replace_chars" {
 variable "list_image" {
   type        = list(string)
   default     = []
-  description = "list of docker local image name, used as a repositry name for AWS-ECR "
+  description = "List of Docker local image names, used as repository names for AWS ECR "
 }


### PR DESCRIPTION
firstly, thanks for great work!
your work helps me lots.

**What:**
I added variables and outputs to create multiple repositories in AWS ECR.

1. passing a list of docker images :
list_image = ["redis", "nginx"]
 
2. then get a map of image name to the repository :
repository_url_map = {
 "redis" = "xxx.dkr.ecr.eu-west-1.amazonaws.com/redis"
 "nginx = "xxx.dkr.ecr.eu-west-1.amazonaws.com/nginx "
}

**Why:**
its convenient that if we could create multiple repositories at once by passing a list of docker images as a argument since AWS ECR assuming one repo per one docker image.