### PR TITLE
Add tag mutability setting to the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Available targets:
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | image_names | List of Docker local image names, used as repository names for AWS ECR | list(string) | `<list>` | no |
+| image_tag_mutability | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | string | `MUTABLE` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
 | image_names | List of Docker local image names, used as repository names for AWS ECR | list(string) | `<list>` | no |
+| image_tag_mutability | The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE` | string | `MUTABLE` | no |
 | max_image_count | How many Docker Image versions AWS ECR will store | string | `500` | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,9 @@ locals {
 }
 
 resource "aws_ecr_repository" "default" {
-  count = var.enabled ? length(local.image_names) : 0
-  name  = local.image_names[count.index]
+  count                = var.enabled ? length(local.image_names) : 0
+  name                 = local.image_names[count.index]
+  image_tag_mutability = var.image_tag_mutability
 
   image_scanning_configuration {
     scan_on_push = var.scan_images_on_push

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,9 @@ variable "image_names" {
   default     = []
   description = "List of Docker local image names, used as repository names for AWS ECR "
 }
+
+variable "image_tag_mutability" {
+  type        = string
+  default     = "MUTABLE"
+  description = "The tag mutability setting for the repository. Must be one of: `MUTABLE` or `IMMUTABLE`"
+}


### PR DESCRIPTION
## what
* Adds a variable to change tag mutability of images in AWS ECR. 

## why
* Image tag immutability is a useful feature supported by AWS ECR, but there is no way of configuring it using this Terraform module.

## references
* Closes #38

