### PR TITLE
fix fullname option functionality with multi-image config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ locals {
 
 resource "aws_ecr_repository" "default" {
   count                = var.enabled ? length(local.image_names) : 0
-  name                 = local.image_names[count.index]
+  name                 = var.use_fullname && length(var.image_names) > 0 ? "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}" : local.image_names[count.index]
   image_tag_mutability = var.image_tag_mutability
 
   image_scanning_configuration {

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_ecr_repository" "default" {
   }
 
   #tags = module.label.tags
-  tags = merge(module.label.tags, map("Name", "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}"))
+  tags = "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}"
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_ecr_repository" "default" {
   }
 
   #tags = module.label.tags
-  tags = "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}"
+  tags = merge(module.label.tags, map("Name", "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}"))
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,8 @@ resource "aws_ecr_repository" "default" {
     scan_on_push = var.scan_images_on_push
   }
 
-  tags = module.label.tags
+  #tags = module.label.tags
+  tags = "${module.label.id}${module.label.delimiter}${local.image_names[count.index]}"
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {


### PR DESCRIPTION
what

fullname option fix: added fullname option functionality when multiple images are defined via image_names. When single name provided ECR created with module.label.id - namespace-stage-name, when multiple images provided with 'image_names' module will skip fullname option and create ECRs with plain names as in image_names skipping prefix, when it actually should add those image-names to base(module.label.id), like ${module.label.id}${module.label.delimiter}${local.image_names[count.index]}
why

    within multi business partner/environment accounts creating ECRs with plain names will will quickly lead to naming conflicts.
    Unfortunately count cannot be accessed outside resource definition so it can't be set within variables block and should go straight into resource block

references

n/a

