### PR TITLE
Variable name for ECRs fixed

### DIFF
--- a/examples/multiple-repo/main.tf
+++ b/examples/multiple-repo/main.tf
@@ -8,5 +8,5 @@ module "ecr" {
   stage        = "dev"
   name         = "app"
   use_fullname = false
-  list_image   = ["redis", "nginx"]
+  image_names  = ["redis", "nginx"]
 }


### PR DESCRIPTION
## what
Correction on the parameter for the names of the ECRs to create, change from **list_image** to **image_names** into examples/multi-repo
## why
Unsupported argument in parameter *list_image* when executing a / apply plan


