### PR TITLE
Allow protecting images with specified tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Available targets:
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | principals\_full\_access | Principal ARNs to provide with full access to the ECR | `list(string)` | `[]` | no |
 | principals\_readonly\_access | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
+| protected\_tags | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | `[]` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only letters, digits, dash, slash, and underscore are allowed, all other chars are removed | `string` | `"/[^a-z/A-Z_0-9-]/"` | no |
 | scan\_images\_on\_push | Indicates whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `false` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,6 +28,7 @@
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | principals\_full\_access | Principal ARNs to provide with full access to the ECR | `list(string)` | `[]` | no |
 | principals\_readonly\_access | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
+| protected\_tags | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | `[]` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`. By default only letters, digits, dash, slash, and underscore are allowed, all other chars are removed | `string` | `"/[^a-z/A-Z_0-9-]/"` | no |
 | scan\_images\_on\_push | Indicates whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `false` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -33,40 +33,58 @@ resource "aws_ecr_repository" "name" {
   tags = module.label.tags
 }
 
-resource "aws_ecr_lifecycle_policy" "name" {
-  for_each   = toset(var.enabled && var.enable_lifecycle_policy ? local.image_names : [])
-  repository = aws_ecr_repository.name[each.value].name
+locals {
+  untagged_image_rule = [{
+    rulePriority = length(var.protected_tags) + 1
+    description  = "Remove untagged images"
+    selection = {
+      tagStatus   = "untagged"
+      countType   = "imageCountMoreThan"
+      countNumber = 1
+    }
+    action = {
+      type = "expire"
+    }
+  }]
 
-  policy = <<EOF
-{
-  "rules": [
+  remove_old_image_rule = [{
+    rulePriority = length(var.protected_tags) + 2
+    description  = "Rotate images when reach ${var.max_image_count} images stored",
+    selection = {
+      tagStatus   = "any"
+      countType   = "imageCountMoreThan"
+      countNumber = var.max_image_count
+    }
+    action = {
+      type = "expire"
+    }
+  }]
+
+  protected_tag_rules = [
+    for index, tagPrefix in zipmap(range(length(var.protected_tags)), tolist(var.protected_tags)) :
     {
-      "rulePriority": 1,
-      "description": "Remove untagged images",
-      "selection": {
-        "tagStatus": "untagged",
-        "countType": "imageCountMoreThan",
-        "countNumber": 1
-      },
-      "action": {
-        "type": "expire"
+      rulePriority = tonumber(index) + 1
+      description  = "Protects images tagged with ${tagPrefix}"
+      selection = {
+        tagStatus     = "tagged"
+        tagPrefixList = [tagPrefix]
+        countType     = "imageCountMoreThan"
+        countNumber   = 999999
       }
-    },
-    {
-      "rulePriority": 2,
-      "description": "Rotate images when reach ${var.max_image_count} images stored",
-      "selection": {
-        "tagStatus": "any",
-        "countType": "imageCountMoreThan",
-        "countNumber": ${var.max_image_count}
-      },
-      "action": {
-        "type": "expire"
+      action = {
+        type = "expire"
       }
     }
   ]
 }
-EOF
+
+resource "aws_ecr_lifecycle_policy" "name" {
+  for_each   = toset(var.enabled && var.enable_lifecycle_policy ? local.image_names : [])
+  repository = aws_ecr_repository.name[each.value].name
+
+  policy = jsonencode({
+    rules = concat(local.protected_tag_rules, local.untagged_image_rule, local.remove_old_image_rule)
+  })
 }
 
 data "aws_iam_policy_document" "empty" {

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,7 @@ variable "scan_images_on_push" {
 }
 
 variable "max_image_count" {
+  type        = number
   description = "How many Docker Image versions AWS ECR will store"
   default     = 500
 }
@@ -90,5 +91,10 @@ variable "enable_lifecycle_policy" {
   type        = bool
   description = "Set to false to prevent the module from adding any lifecycle policies to any repositories"
   default     = true
+}
 
+variable "protected_tags" {
+  type        = set(string)
+  description = "Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod`"
+  default     = []
 }


### PR DESCRIPTION
## what
* Allow protecting images with a given set of tag names

## why
* At Transcend, we tag images with `dev`, `staging`, and `prod` for deployments in addition to their SHA tags. We want to expire images, but not those actively is use.

## references
* https://github.com/aws/containers-roadmap/issues/637
* https://docs.aws.amazon.com/AmazonECR/latest/userguide/lifecycle_policy_examples.html

Note: This change is fully backwards compatible
