### PR TITLE
Use correct variable for multiple images

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,22 +268,24 @@ Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 See [LICENSE](LICENSE) for full details.
 
-    Licensed to the Apache Software Foundation (ASF) under one
-    or more contributor license agreements.  See the NOTICE file
-    distributed with this work for additional information
-    regarding copyright ownership.  The ASF licenses this file
-    to you under the Apache License, Version 2.0 (the
-    "License"); you may not use this file except in compliance
-    with the License.  You may obtain a copy of the License at
+```text
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
 
-      https://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an
-    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-    KIND, either express or implied.  See the License for the
-    specific language governing permissions and limitations
-    under the License.
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+```
 
 
 

--- a/examples/multiple-repo/main.tf
+++ b/examples/multiple-repo/main.tf
@@ -8,5 +8,5 @@ module "ecr" {
   stage        = "dev"
   name         = "app"
   use_fullname = false
-  list_image   = ["redis", "nginx"]
+  image_names  = ["redis", "nginx"]
 }


### PR DESCRIPTION
Looks like in [MR-41](https://github.com/cloudposse/terraform-aws-ecr/pull/41) we added a broken exapmle for deploying ecr with multiple repos. Also the test does not seem to cover this example. Do we want to test this example?