### PR TITLE
Update IAM action lists

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,15 +101,18 @@ data "aws_iam_policy_document" "resource_readonly_access" {
     }
 
     actions = [
-      "ecr:GetAuthorizationToken",
       "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
       "ecr:BatchGetImage",
       "ecr:DescribeImageScanFindings",
+      "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetLifecyclePolicy",
+      "ecr:GetLifecyclePolicyPreview",
+      "ecr:GetRepositoryPolicy",
+      "ecr:ListImages",
+      "ecr:ListTagsForResource",
     ]
   }
 }
@@ -127,26 +130,7 @@ data "aws_iam_policy_document" "resource_full_access" {
       identifiers = var.principals_full_access
     }
 
-    actions = [
-      "ecr:GetAuthorizationToken",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload",
-      "ecr:PutImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:GetRepositoryPolicy",
-      "ecr:DescribeRepositories",
-      "ecr:ListImages",
-      "ecr:DescribeImages",
-      "ecr:BatchGetImage",
-      "ecr:DescribeImageScanFindings",
-      "ecr:StartImageScan",
-      "ecr:BatchDeleteImage",
-      "ecr:SetRepositoryPolicy",
-      "ecr:DeleteRepositoryPolicy",
-      "ecr:DeleteRepository",
-    ]
+    actions = ["ecr:*"]
   }
 }
 


### PR DESCRIPTION
## what

- Update read-only access to include 
   - `ecr:GetLifecyclePolicy`
   - `ecr:GetLifecyclePolicyPreview`
  -  `ecr:ListTagsForResource`
- Update full access to `ecr:*`

## why

- New features (and corresponding actions) have been added, such as Lifecycle and Image Scan policies.