### PR TITLE
Remove ecr:GetAuthorizationToken from read-only access

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,7 +106,6 @@ data "aws_iam_policy_document" "resource_readonly_access" {
       "ecr:DescribeImageScanFindings",
       "ecr:DescribeImages",
       "ecr:DescribeRepositories",
-      "ecr:GetAuthorizationToken",
       "ecr:GetDownloadUrlForLayer",
       "ecr:GetLifecyclePolicy",
       "ecr:GetLifecyclePolicyPreview",


### PR DESCRIPTION
## what
- Remove `ecr:GetAuthorizationToken` from read-only access

## why

- This module has included `ecr:GetAuthorizationToken` for years, but today AWS is rejecting it in the Repository Policy, saying "Invalid repository policy provided"


