### PR TITLE
Fix aws provider v4 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.1"
+      version = ">= 3.30.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -223,9 +223,9 @@ data "aws_iam_policy_document" "resource_full_access" {
 }
 
 data "aws_iam_policy_document" "resource" {
-  count         = module.this.enabled ? 1 : 0
-  source_json   = local.principals_readonly_access_non_empty ? join("", [data.aws_iam_policy_document.resource_readonly_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
-  override_json = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
+  count                     = module.this.enabled ? 1 : 0
+  source_policy_documents   = local.principals_readonly_access_non_empty ? join("", [data.aws_iam_policy_document.resource_readonly_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
+  override_policy_documents = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
 }
 
 resource "aws_ecr_repository_policy" "name" {

--- a/main.tf
+++ b/main.tf
@@ -224,8 +224,8 @@ data "aws_iam_policy_document" "resource_full_access" {
 
 data "aws_iam_policy_document" "resource" {
   count                     = module.this.enabled ? 1 : 0
-  source_policy_documents   = local.principals_readonly_access_non_empty ? join("", [data.aws_iam_policy_document.resource_readonly_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
-  override_policy_documents = local.principals_full_access_non_empty ? join("", [data.aws_iam_policy_document.resource_full_access[0].json]) : join("", [data.aws_iam_policy_document.empty[0].json])
+  source_policy_documents   = local.principals_readonly_access_non_empty ? [data.aws_iam_policy_document.resource_readonly_access[0].json] : [data.aws_iam_policy_document.empty[0].json]
+  override_policy_documents = local.principals_full_access_non_empty ? [data.aws_iam_policy_document.resource_full_access[0].json] : [data.aws_iam_policy_document.empty[0].json]
 }
 
 resource "aws_ecr_repository_policy" "name" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.1"
+      version = ">= 3.30.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Replace deprecated parameters in aws v4

## why
* Make module compatible with v4

## references
* Closes https://github.com/cloudposse/terraform-aws-ecr/issues/91

