### PR TITLE
feat: CAI-1996 Add region replication functionality

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,35 +1,35 @@
 output "registry_id" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].registry_id : ""
+  value       = module.this.enabled && !var.only_repository_policy ? aws_ecr_repository.name[local.image_names[0]].registry_id : ""
   description = "Registry ID"
 }
 
 output "repository_name" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].name : ""
+  value       = module.this.enabled && !var.only_repository_policy ? aws_ecr_repository.name[local.image_names[0]].name : ""
   description = "Name of first repository created"
 }
 
 output "repository_url" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].repository_url : ""
+  value       = module.this.enabled && !var.only_repository_policy ? aws_ecr_repository.name[local.image_names[0]].repository_url : ""
   description = "URL of first repository created"
 }
 
 output "repository_arn" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].arn : ""
+  value       = module.this.enabled && !var.only_repository_policy ? aws_ecr_repository.name[local.image_names[0]].arn : ""
   description = "ARN of first repository created"
 }
 
 output "repository_url_map" {
-  value = zipmap(
+  value = module.this.enabled && !var.only_repository_policy ? zipmap(
     values(aws_ecr_repository.name)[*].name,
     values(aws_ecr_repository.name)[*].repository_url
-  )
+  ) : {}
   description = "Map of repository names to repository URLs"
 }
 
 output "repository_arn_map" {
-  value = zipmap(
+  value = module.this.enabled && !var.only_repository_policy ? zipmap(
     values(aws_ecr_repository.name)[*].name,
     values(aws_ecr_repository.name)[*].arn
-  )
+  ) : {}
   description = "Map of repository names to repository ARNs"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,15 @@ variable "force_delete" {
   description = "Whether to delete the repository even if it contains images"
   default     = false
 }
+
+variable "replication_regions" {
+  type        = set(string)
+  default     = []
+  description = "List of destination regions in the same account for which to replicate ECR images to."
+}
+
+variable "only_repository_policy" {
+  type        = bool
+  description = "Whether to skip creating repositories and only modify the policy for existing repositories"
+  default     = false
+}


### PR DESCRIPTION
## what

- Add ECR repository replication to different regions.
- Add new mode for replication-destination regions to only modify the repository policy.

## why

- We currently have to add our own replication functionality.
- Replication is only for repository images, it does not replicate the policy, so none of the images can actually be pulled without some ability to create a policy in the destination region.

## implications

- I already did some test plans locally, but this would mean we would add a `mgmt-ew1-artifacts.yaml` w/ the following config:
```
components:
  terraform:
    ecr:
      vars:
        enable_lifecycle_policy: false
        only_permissions: true
```

## references

- https://brightai.atlassian.net/browse/CAI-1996
