### PR TITLE
fix: Typo in pull-through-access variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Available targets:
 | <a name="input_prefixes_pull_through_repositories"></a> [prefixes\_pull\_through\_repositories](#input\_prefixes\_pull\_through\_repositories) | Organization IDs to provide with push access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_full_access"></a> [principals\_full\_access](#input\_principals\_full\_access) | Principal ARNs to provide with full access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_lambda"></a> [principals\_lambda](#input\_principals\_lambda) | Principal account IDs of Lambdas allowed to consume ECR | `list(string)` | `[]` | no |
-| <a name="input_principals_pull_though_access"></a> [principals\_pull\_though\_access](#input\_principals\_pull\_though\_access) | Principal ARNs to provide with pull though access to the ECR | `list(string)` | `[]` | no |
+| <a name="input_principals_pull_through_access"></a> [principals\_pull\_through\_access](#input\_principals\_pull\_through\_access) | Principal ARNs to provide with pull through access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_push_access"></a> [principals\_push\_access](#input\_principals\_push\_access) | Principal ARNs to provide with push access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_readonly_access"></a> [principals\_readonly\_access](#input\_principals\_readonly\_access) | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | `[]` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -68,7 +68,7 @@
 | <a name="input_prefixes_pull_through_repositories"></a> [prefixes\_pull\_through\_repositories](#input\_prefixes\_pull\_through\_repositories) | Organization IDs to provide with push access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_full_access"></a> [principals\_full\_access](#input\_principals\_full\_access) | Principal ARNs to provide with full access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_lambda"></a> [principals\_lambda](#input\_principals\_lambda) | Principal account IDs of Lambdas allowed to consume ECR | `list(string)` | `[]` | no |
-| <a name="input_principals_pull_though_access"></a> [principals\_pull\_though\_access](#input\_principals\_pull\_though\_access) | Principal ARNs to provide with pull though access to the ECR | `list(string)` | `[]` | no |
+| <a name="input_principals_pull_through_access"></a> [principals\_pull\_through\_access](#input\_principals\_pull\_through\_access) | Principal ARNs to provide with pull through access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_push_access"></a> [principals\_push\_access](#input\_principals\_push\_access) | Principal ARNs to provide with push access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_principals_readonly_access"></a> [principals\_readonly\_access](#input\_principals\_readonly\_access) | Principal ARNs to provide with readonly access to the ECR | `list(string)` | `[]` | no |
 | <a name="input_protected_tags"></a> [protected\_tags](#input\_protected\_tags) | Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod` | `set(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   principals_readonly_access_non_empty     = length(var.principals_readonly_access) > 0
-  principals_pull_through_access_non_empty = length(var.principals_pull_though_access) > 0
+  principals_pull_through_access_non_empty = length(var.principals_pull_through_access) > 0
   principals_push_access_non_empty         = length(var.principals_push_access) > 0
   principals_full_access_non_empty         = length(var.principals_full_access) > 0
   principals_lambda_non_empty              = length(var.principals_lambda) > 0
@@ -11,7 +11,7 @@ locals {
   ecr_need_policy = (
     length(var.principals_full_access)
     + length(var.principals_readonly_access)
-    + length(var.principals_pull_though_access)
+    + length(var.principals_pull_through_access)
     + length(var.principals_push_access)
     + length(var.principals_lambda)
     + length(var.organizations_readonly_access)
@@ -147,7 +147,7 @@ data "aws_iam_policy_document" "resource_pull_through_cache" {
 
     principals {
       type        = "AWS"
-      identifiers = var.principals_pull_though_access
+      identifiers = var.principals_pull_through_access
     }
 
     actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -22,9 +22,9 @@ variable "principals_readonly_access" {
   default     = []
 }
 
-variable "principals_pull_though_access" {
+variable "principals_pull_through_access" {
   type        = list(string)
-  description = "Principal ARNs to provide with pull though access to the ECR"
+  description = "Principal ARNs to provide with pull through access to the ECR"
   default     = []
 }
 


### PR DESCRIPTION
## what

Fix typo in the `principals_pull_through_access` variable

```diff
- principals_pull_though_access
+ principals_pull_through_access
```

## why

Just making the code a little bit cleaner

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
