### PR TITLE
fix(#133): have ability to use wildcards in protected_tags variale

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "enable_lifecycle_policy" {
 
 variable "protected_tags" {
   type        = set(string)
-  description = "Name of image tags prefixes that should not be destroyed. Useful if you tag images with names like `dev`, `staging`, and `prod`"
+  description = "List of image tags prefixes and wildcards that should not be destroyed. Useful if you tag images with prefixes like `dev`, `staging`, `prod` or wildcards like `*dev`, `*prod`,`*.*.*`"
   default     = []
 }
 


### PR DESCRIPTION
## what

- the change allows to pass wildcards in protected_tags list

## why

- there are use cases when the protected tags are not only prefix defineable and only wildcard can be used like "*prod" or semversion `*.*.*`

## references

- fixes #133 