### PR TITLE
Removal Repository Factory

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -56,18 +56,15 @@ description: |-
 
 # How to use this project
 usage: |-
-  The module creates one or more Elastic Container Registry (ECR) repositories. All repositories created
-  will share the same configuration. Use this module multiple times to create repositories with
-  different configurations.
+  > ![Note]
+  > Please note this module has undergone a major release that changes it from supporting multiple ECR repositories to a single ECR repository.
+  > This is in order to better support customization of each Repository.
+  > 
+  > The ECR Component will still create a single ECR Repository, to create them in mass, we recommend using atmos stacks and inheritance.
 
-  If you provide 1 or more names in `image_names` then one repository will be created for
-  each of the names you provide. Those names can include "namespaces", which are just
-  prefixes ending with a slash (`/`).
+  The module creates a **single** Elastic Container Registry (ECR) repository. 
 
-  If you do not provide any names in `image_names`, the module will create a single ECR repo
-  named `namespace-stage-name` or just `name` depending on the value of `use_fullname`.
-
-  Access to the repositories is granted to via the `principals_full_access` and
+  Access to the repository is granted to via the `principals_full_access` and
   `principals_readonly_access` lists, which are lists of strings that can designate [any valid AWS
   Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#Principal_specifying).
   This module only creates the Repository Policy allowing those Principals access.

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,35 +1,19 @@
 output "registry_id" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].registry_id : ""
+  value       = module.this.enabled ? aws_ecr_repository.this[0].registry_id : ""
   description = "Registry ID"
 }
 
 output "repository_name" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].name : ""
+  value       = module.this.enabled ? aws_ecr_repository.this[0].name : ""
   description = "Name of first repository created"
 }
 
 output "repository_url" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].repository_url : ""
+  value       = module.this.enabled ? aws_ecr_repository.this[0].repository_url : ""
   description = "URL of first repository created"
 }
 
 output "repository_arn" {
-  value       = module.this.enabled ? aws_ecr_repository.name[local.image_names[0]].arn : ""
+  value       = module.this.enabled ? aws_ecr_repository.this[0].arn : ""
   description = "ARN of first repository created"
-}
-
-output "repository_url_map" {
-  value = zipmap(
-    values(aws_ecr_repository.name)[*].name,
-    values(aws_ecr_repository.name)[*].repository_url
-  )
-  description = "Map of repository names to repository URLs"
-}
-
-output "repository_arn_map" {
-  value = zipmap(
-    values(aws_ecr_repository.name)[*].name,
-    values(aws_ecr_repository.name)[*].arn
-  )
-  description = "Map of repository names to repository ARNs"
 }


### PR DESCRIPTION
The major purpose of this Pull Request is to move the "heavy lifting" of managing ECR Repositories from this one component an d module to atmos stacks

## what
 - Removes for_each of image_name that creates several ECR Repositories.
 - Removes "built in" ECR Lifecycle Policies
 - Removes outputs that previosuly declared the entire ECR Map.

## why
 This is an initially controversial change. We are removing some of the "Batteries included" in our module, in exchange we are improving the flexibility of it. I initially was not in favor of this change so let me now try to convince you as I was.
 
### Questions
 > Our Component currently outputs the entire ARN map of all ECR Repositories which is useful for other components to look up and add to IAM Permissions.

Turns out, the only thing looking up ECR Repository ARNs is the attached GitHub role that allows pushing to the ECR. If we want to create a role that can push to any ECR, there's a data source to look up all repositories, and it's not that hard to recreate.Having this module handle individual repositories also allows our component to then create specific roles for GitHub Actions to assume to be able to push to individual repositories. This allows much finer-grained controls and tighter permissions. And of course, there's always a wild card option if you want to go back.

> How is this more flexible?

This is more flexible because our component in this module can now create custom lifecycle policies and custom rules per individual repositories.

> Isn't this less dry?


There are two thoughts to this. 

One is, if you're using atmos, you can simply create stacks. These stacks can be repeated either using templating or with inheritance to become very dry themselves. Creating stack configurations—a snippet of YAML—is very easy and fast, and oftentimes it's a 1-up or CI is going to handle reapplying it frequently.

Since stacks are so easy to create, this allows us to still be very dry and not need to apply terraform components that affect many resources.

The second is, if you're not using atmos and you're just using this module, you can always surround it in a foreach—and that's not that hard. 

